### PR TITLE
Add NULL checks to memory allocation functions

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -872,6 +872,7 @@ linenoiseCompletionCallback * linenoiseSetCompletionCallback(linenoiseCompletion
 
 void linenoiseAddCompletion(linenoiseCompletions *lc, const char *str) {
     lc->cvec = (char **)realloc(lc->cvec,sizeof(char*)*(lc->len+1));
+    assert(lc->cvec);
     lc->cvec[lc->len++] = strdup(str);
 }
 
@@ -1742,8 +1743,10 @@ history_navigation:
             if (history_len > 1) {
                 /* Update the current history entry before to
                  * overwrite it with tne next one. */
-                free(history[history_len - 1 - history_index]);
-                history[history_len - 1 - history_index] = strdup(sb_str(current->buf));
+                int index = history_len - 1 - history_index;
+                free(history[index]);
+                history[index] = strdup(sb_str(current->buf));
+                assert(history[index]);
                 /* Show the new entry */
                 history_index += dir;
                 if (history_index < 0) {
@@ -1895,6 +1898,7 @@ notinserted:
     }
     if (history == NULL) {
         history = (char **)calloc(sizeof(char*), history_max_len);
+        assert(history);
     }
 
     /* do not insert duplicate lines into history */
@@ -1913,7 +1917,9 @@ notinserted:
 }
 
 int linenoiseHistoryAdd(const char *line) {
-    return linenoiseHistoryAddAllocated(strdup(line));
+    char *new_line = strdup(line);
+    assert(new_line);
+    return linenoiseHistoryAddAllocated(new_line);
 }
 
 int linenoiseHistoryGetMaxLen(void) {
@@ -1928,6 +1934,7 @@ int linenoiseHistorySetMaxLen(int len) {
         int tocopy = history_len;
 
         newHistory = (char **)calloc(sizeof(char*), len);
+        assert(newHistory);
 
         /* If we can't copy everything, free the elements we'll not use. */
         if (len < tocopy) {
@@ -1993,6 +2000,7 @@ int linenoiseHistoryLoad(const char *filename) {
     while ((sb = sb_getline(fp)) != NULL) {
         /* Take the stringbuf and decode backslash escaped values */
         char *buf = sb_to_string(sb);
+        assert(buf);
         char *dest = buf;
         const char *src;
 

--- a/stringbuf.c
+++ b/stringbuf.c
@@ -25,6 +25,7 @@
 stringbuf *sb_alloc(void)
 {
 	stringbuf *sb = (stringbuf *)malloc(sizeof(*sb));
+	assert(sb);
 	sb->remaining = 0;
 	sb->last = 0;
 #ifdef USE_UTF8


### PR DESCRIPTION
strdup(), malloc(), realloc(), etc. may return NULL. Hence, the caller
should handle it to prevent NULL pointer exceptions.

This bug was discovered and resolved using Coverity Static Analysis
Security Testing (SAST) by Synopsys, Inc.

Signed-off-by: Metin Kaya <metikaya@amazon.co.uk>