### PR TITLE
Add NULL checks to memory allocation functions

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -879,6 +879,8 @@ linenoiseCompletionCallback * linenoiseSetCompletionCallback(linenoiseCompletion
 
 void linenoiseAddCompletion(linenoiseCompletions *lc, const char *str) {
     lc->cvec = (char **)realloc(lc->cvec,sizeof(char*)*(lc->len+1));
+    if (!lc->cvec)
+        return;
     lc->cvec[lc->len++] = strdup(str);
 }
 
@@ -1785,8 +1787,11 @@ history_navigation:
             if (history_len > 1) {
                 /* Update the current history entry before to
                  * overwrite it with tne next one. */
-                free(history[history_len - 1 - history_index]);
-                history[history_len - 1 - history_index] = strdup(sb_str(current->buf));
+                int index = history_len - 1 - history_index;
+                free(history[index]);
+                history[index] = strdup(sb_str(current->buf));
+                if (!history[index])
+                    return -1;
                 /* Show the new entry */
                 history_index += dir;
                 if (history_index < 0) {
@@ -1951,6 +1956,8 @@ notinserted:
     }
     if (history == NULL) {
         history = (char **)calloc(sizeof(char*), history_max_len);
+        if (!history)
+            goto notinserted;
     }
 
     /* do not insert duplicate lines into history */
@@ -1969,7 +1976,10 @@ notinserted:
 }
 
 int linenoiseHistoryAdd(const char *line) {
-    return linenoiseHistoryAddAllocated(strdup(line));
+    char *new_line = strdup(line);
+    if (!new_line)
+        return 0;
+    return linenoiseHistoryAddAllocated(new_line);
 }
 
 int linenoiseHistoryGetMaxLen(void) {
@@ -1984,6 +1994,8 @@ int linenoiseHistorySetMaxLen(int len) {
         int tocopy = history_len;
 
         newHistory = (char **)calloc(sizeof(char*), len);
+        if (!newHistory)
+            return 0;
 
         /* If we can't copy everything, free the elements we'll not use. */
         if (len < tocopy) {
@@ -2049,6 +2061,10 @@ int linenoiseHistoryLoad(const char *filename) {
     while ((sb = sb_getline(fp)) != NULL) {
         /* Take the stringbuf and decode backslash escaped values */
         char *buf = sb_to_string(sb);
+        if (!buf) {
+            fclose(fp);
+            return -1;
+        }
         char *dest = buf;
         const char *src;
 

--- a/stringbuf.c
+++ b/stringbuf.c
@@ -25,6 +25,8 @@
 stringbuf *sb_alloc(void)
 {
 	stringbuf *sb = (stringbuf *)malloc(sizeof(*sb));
+	if (!sb)
+		return NULL;
 	sb->remaining = 0;
 	sb->last = 0;
 #ifdef USE_UTF8


### PR DESCRIPTION
strdup(), malloc(), realloc(), etc. may return NULL. Hence, the caller should handle it to prevent NULL pointer exceptions.

This bug was discovered and resolved using Coverity Static Analysis Security Testing (SAST) by Synopsys, Inc.

Signed-off-by: Metin Kaya <metikaya@amazon.co.uk>